### PR TITLE
re: improve locale ja  / chore change

### DIFF
--- a/locales/ja.json
+++ b/locales/ja.json
@@ -19,7 +19,7 @@
     "downloads": {
         "macOS": "macOS",
         "linux": "Linux",
-        "windowsSetup": "Windows セットアップ",
+        "windowsSetup": "Windows インストーラー",
         "windowsStandalone": "Windows スタンドアロン",
         "unsuportedOS": "非対応のOS"
     },

--- a/public/alcom/index.hbs
+++ b/public/alcom/index.hbs
@@ -66,7 +66,7 @@
                     </a>
                     <a class="p-contextual-menu__link" id="btn-download-linux" href="https://github.com/vrc-get/vrc-get/releases/download/gui-v{{data.latestAlcomVersion}}/alcom-{{data.latestAlcomVersion}}-x86_64.AppImage">
                         <i class="p-icon ri-ubuntu-line me-1"></i>
-                        {{downloads.linux}} <code class="ms-1">AppImage</code>
+                        {{downloads.linux}} <code class="ms-1">.AppImage</code>
                     </a>
                 </span>
             </span>


### PR DESCRIPTION
忘れていたところを修正

macOSを`macOS ディスクイメージ`、Linuxを`Linux インストーラー`とするとWindows用表記と統一感があって良さそうだなと思ったりもしていますが、どう思いますか?